### PR TITLE
reset API

### DIFF
--- a/simulation/unity_simulator/comm_unity.py
+++ b/simulation/unity_simulator/comm_unity.py
@@ -267,8 +267,6 @@ class UnityCommunication(object):
         :param int environment: integer between 0 and 49, corresponding to the apartment we want to load
         :return: succes (bool)
         """
-        response = self.post_command({'id': str(time.time()), 'action': 'clear',
-                                  'intParams': [] if environment is None else [environment]})
         response = self.post_command({'id': str(time.time()), 'action': 'environment',
                                     'intParams': [] if environment is None else [environment]})
         return response['success']


### PR DESCRIPTION
Sending the message like {"id":745836230,"action":"clear","intParams":[4]} gets
{ "id" : 745836230, "success": false, "message" : "Unknown action" , "value": 0 } .
The message  {"action" : "environment", "intParams":[4]} seems to reload the environment.