### PR TITLE
added collections.Iterable compatability with Python 3.10+

### DIFF
--- a/virtualhome/simulation/unity_simulator/comm_unity.py
+++ b/virtualhome/simulation/unity_simulator/comm_unity.py
@@ -58,6 +58,10 @@ class UnityCommunication(object):
                         time.sleep(2)
                 if not succeeded:
                     sys.exit()
+                    
+        # collections.Iterable was depreciated in Python 3.10, ensure compatability with current Python versions
+        if not hasattr(collections, 'Iterable'):
+            collections.Iterable = collections.abc.Iterable
 
     def requests_retry_session(
                             self,


### PR DESCRIPTION
In Python 3.10, collections.Iterable was depreciated in favor of collections.abc.Iterable.

This commit sets collections.Iterable to collections.abc.Iterable when collections.Iterable does not already exist (current Python).

The change should be compatible with existing systems with older Python versions.