### PR TITLE
Corrected setup.py source folder

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,8 @@ setuptools.setup(
         'tqdm==4.31.1',
         'urllib3>=1.24.3'
     ],
-    package_dir={"": "src"},
-    packages=setuptools.find_packages(where="src"),
+    package_dir={"": "."},
+    packages=setuptools.find_packages(where="."),
     python_requires=">=3.10",
 )
 


### PR DESCRIPTION
setup.py was configured to look for a "src" folder, which does not reflect the codebase structure.

This commit changes the source directory from the missing "src" to ".". As per issue #125 this works for Windows platforms.