### PR TITLE
Fixed simulator imports for local installs

### DIFF
--- a/virtualhome/__init__.py
+++ b/virtualhome/__init__.py
@@ -7,5 +7,12 @@ original_path = sys.path[5]
 new_path = original_path + '/virtualhome/simulation'
 sys.path.append(new_path)
 
-from unity_simulator.comm_unity import UnityCommunication
-from unity_simulator import utils_viz
+# if installed via pip
+try:
+    from unity_simulator.comm_unity import UnityCommunication
+    from unity_simulator import utils_viz
+
+# if running locally (cloned into the project repository)
+except ModuleNotFoundError:
+    from .simulation.unity_simulator.comm_unity import UnityCommunication
+    from .simulation.unity_simulator import utils_viz


### PR DESCRIPTION
The Getting Started instructions (http://virtual-home.org/documentation/master/get_started/get_started.html) state to clone the repo and no other installation setup. However, in Python 3.12 (I am unsure about earlier versions) the imports in the Getting Started guide fail (ModuleNotFoundError).

This commit wraps the top-level \_\_init\_\_.py submodule imports in a try/catch that allows for importing virtualhome modules from parent folders.