### PR TITLE
Removed semicolons from Python Jupyter Notebook code

### DIFF
--- a/virtualhome/demo/unity_demo.ipynb
+++ b/virtualhome/demo/unity_demo.ipynb
@@ -619,7 +619,7 @@
    },
    "outputs": [],
    "source": [
-    "success, graph = comm.environment_graph();\n",
+    "success, graph = comm.environment_graph()\n",
     "sofa = find_nodes(graph, class_name='sofa')[-2]\n",
     "print(sofa)"
    ]
@@ -746,7 +746,7 @@
    },
    "outputs": [],
    "source": [
-    "success, graph = comm.environment_graph();"
+    "success, graph = comm.environment_graph()"
    ]
   },
   {


### PR DESCRIPTION
Simple typo.