### PR TITLE
Added list param validation to render_script

### DIFF
--- a/virtualhome/simulation/unity_simulator/comm_unity.py
+++ b/virtualhome/simulation/unity_simulator/comm_unity.py
@@ -480,6 +480,12 @@ class UnityCommunication(object):
 
         :return: pair success (bool), message: (str)
         """
+
+        # validate parameters
+        assert isinstance(script, list), "script must be a list of strings"
+        assert isinstance(image_synthesis, list), "image_synthesis must be a list of strings"
+        assert isinstance(camera_mode, list), "camera_mode must be a list of strings"
+        
         params = {'randomize_execution': randomize_execution, 'random_seed': random_seed,
                   'processing_time_limit': processing_time_limit, 'skip_execution': skip_execution,
                   'output_folder': output_folder, 'file_name_prefix': file_name_prefix,


### PR DESCRIPTION
It is easy to pass in strings instead of lists for script, image_synthesis, and camera_mode to render_script(). Doing so results in behavior that is hard to deduce the cause of.

This commit checks those variable types, also raised in issue #94